### PR TITLE
Fix instagram bugs and test discovery

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -53,7 +53,6 @@
 </div>
 
 <!-- Histórico Completo de Sorteios Passados -->
-{% if historico_semanal %}
 <div class="container-fluid px-4 mt-4">
     <div class="row">
         <div class="col-12">
@@ -67,23 +66,29 @@
             </div>
         </div>
     </div>
-
-    {% for semana in historico_semanal %}
-    <div class="row mb-5">
-        <div class="col-12">
-            <div class="semana-sorteio-card">
-                <div class="semana-header">
-                    <i class="bi bi-calendar2-week-fill"></i>
-                    Semana de {{ semana.intervalo_semana }}
-                </div>
-                <div class="semana-body">
-                    {% set sorteio_da_semana = semana %}
-                    {% include 'partials/semana_sorteio_body.html' with context %}
+    {% if historico_semanal %}
+        {% for semana in historico_semanal %}
+        <div class="row mb-5">
+            <div class="col-12">
+                <div class="semana-sorteio-card">
+                    <div class="semana-header">
+                        <i class="bi bi-calendar2-week-fill"></i>
+                        Semana de {{ semana.intervalo_semana }}
+                    </div>
+                    <div class="semana-body">
+                        {% set sorteio_da_semana = semana %}
+                        {% include 'partials/semana_sorteio_body.html' with context %}
+                    </div>
                 </div>
             </div>
         </div>
+        {% endfor %}
+    {% else %}
+    <div class="row">
+        <div class="col-12 text-center text-muted">
+            Nenhum sorteio anterior disponível.
+        </div>
     </div>
-    {% endfor %}
+    {% endif %}
 </div>
-{% endif %}
-{% endblock %} 
+{% endblock %}

--- a/tests/run_all_tests.py
+++ b/tests/run_all_tests.py
@@ -18,7 +18,8 @@ def run_all_tests():
     # Descobrir todos os testes
     loader = unittest.TestLoader()
     start_dir = os.path.dirname(__file__)
-    suite = loader.discover(start_dir, pattern='test_*.py')
+    top_level_dir = os.path.abspath(os.path.join(start_dir, '..'))
+    suite = loader.discover(start_dir=start_dir, pattern='test_*.py', top_level_dir=top_level_dir)
     
     # Executar os testes
     stream = StringIO()

--- a/uploads/posts.txt
+++ b/uploads/posts.txt
@@ -1,0 +1,1224 @@
+Foto do perfil de rivaldo.rodrigues_
+rivaldo.rodrigues_
+1 h
+eu quero participar
+Foto do perfil de rivaldo.rodrigues_
+rivaldo.rodrigues_
+1 h
+eu quero participar
+Foto do perfil de rivaldo.rodrigues_
+rivaldo.rodrigues_
+1 h
+eu quero participar
+Foto do perfil de rivaldo.rodrigues_
+rivaldo.rodrigues_
+1 h
+eu quero participar
+Foto do perfil de rivaldo.rodrigues_
+rivaldo.rodrigues_
+1 h
+eu quero participar
+Foto do perfil de rivaldo.rodrigues_
+rivaldo.rodrigues_
+1 h
+eu quero participar
+Foto do perfil de rivaldo.rodrigues_
+rivaldo.rodrigues_
+1 h
+eu quero participar
+Foto do perfil de rivaldo.rodrigues_
+rivaldo.rodrigues_
+1 h
+eu quero participar
+Foto do perfil de rivaldo.rodrigues_
+rivaldo.rodrigues_
+1 h
+eu quero participar
+Foto do perfil de rivaldo.rodrigues_
+rivaldo.rodrigues_
+1 h
+eu quero participar
+Foto do perfil de rivaldo.rodrigues_
+rivaldo.rodrigues_
+1 h
+eu quero participar
+Foto do perfil de rivaldo.rodrigues_
+rivaldo.rodrigues_
+1 h
+eu quero participar
+Foto do perfil de rivaldo.rodrigues_
+rivaldo.rodrigues_
+1 h
+eu quero participar
+Foto do perfil de rivaldo.rodrigues_
+rivaldo.rodrigues_
+1 h
+eu quero participar
+Foto do perfil de rivaldo.rodrigues_
+rivaldo.rodrigues_
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de van3ssasousa
+van3ssasousa
+1 h
+eu quero participar
+Foto do perfil de ricardoloiola
+ricardoloiola
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de luenymello
+luenymello
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de elane_oliveiralima
+elane_oliveiralima
+1 h
+eu quero participar
+Foto do perfil de patymorena1
+patymorena1
+1 h
+eu quero participar
+Foto do perfil de patymorena1
+patymorena1
+1 h
+eu quero participar
+Foto do perfil de patymorena1
+patymorena1
+1 h
+eu quero participar
+Foto do perfil de patymorena1
+patymorena1
+1 h
+eu quero participar
+Foto do perfil de patymorena1
+patymorena1
+1 h
+eu quero participar
+Foto do perfil de patymorena1
+patymorena1
+1 h
+eu quero participar
+Foto do perfil de patymorena1
+patymorena1
+1 h
+eu quero participar
+Foto do perfil de patymorena1
+patymorena1
+1 h
+eu quero participar
+Foto do perfil de patymorena1
+patymorena1
+1 h
+eu quero participar
+Foto do perfil de patymorena1
+patymorena1
+1 h
+eu quero participar
+Foto do perfil de patymorena1
+patymorena1
+1 h
+eu quero participar
+Foto do perfil de patymorena1
+patymorena1
+1 h
+eu quero participar
+Foto do perfil de patymorena1
+patymorena1
+1 h
+eu quero participar
+Foto do perfil de patymorena1
+patymorena1
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de sr_batista_
+sr_batista_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de niveabelfort_
+niveabelfort_
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de vitorr_hgoo
+vitorr_hgoo
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de lucasdesousa01
+lucasdesousa01
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de gildenir.muniz
+gildenir.muniz
+1 h
+eu quero participar
+Foto do perfil de user27
+user27
+2 h
+eu quero
+Foto do perfil de user2
+user2
+2 h
+eu quero
+Foto do perfil de user35
+user35
+2 h
+eu quero
+Foto do perfil de user13
+user13
+2 h
+eu quero
+Foto do perfil de user38
+user38
+2 h
+eu quero
+Foto do perfil de user28
+user28
+2 h
+eu quero
+Foto do perfil de user23
+user23
+2 h
+eu quero
+Foto do perfil de user31
+user31
+2 h
+eu quero
+Foto do perfil de user50
+user50
+2 h
+eu quero
+Foto do perfil de user20
+user20
+2 h
+eu quero
+Foto do perfil de user44
+user44
+2 h
+eu quero
+Foto do perfil de user34
+user34
+2 h
+eu quero
+Foto do perfil de user19
+user19
+2 h
+eu quero
+Foto do perfil de user45
+user45
+2 h
+eu quero
+Foto do perfil de user48
+user48
+2 h
+eu quero
+Foto do perfil de user25
+user25
+2 h
+eu quero
+Foto do perfil de user5
+user5
+2 h
+eu quero
+Foto do perfil de user6
+user6
+2 h
+eu quero
+Foto do perfil de user40
+user40
+2 h
+eu quero
+Foto do perfil de user43
+user43
+2 h
+eu quero
+Foto do perfil de user47
+user47
+2 h
+eu quero
+Foto do perfil de user11
+user11
+2 h
+eu quero
+Foto do perfil de user3
+user3
+2 h
+eu quero
+Foto do perfil de user21
+user21
+2 h
+eu quero
+Foto do perfil de user29
+user29
+2 h
+eu quero
+Foto do perfil de user7
+user7
+2 h
+eu quero
+Foto do perfil de user24
+user24
+2 h
+eu quero
+Foto do perfil de user49
+user49
+2 h
+eu quero
+Foto do perfil de user32
+user32
+2 h
+eu quero
+Foto do perfil de user1
+user1
+2 h
+eu quero
+Foto do perfil de user26
+user26
+2 h
+eu quero
+Foto do perfil de user51
+user51
+2 h
+eu quero
+Foto do perfil de user15
+user15
+2 h
+eu quero
+Foto do perfil de user4
+user4
+2 h
+eu quero
+Foto do perfil de user42
+user42
+2 h
+eu quero
+Foto do perfil de user37
+user37
+2 h
+eu quero
+Foto do perfil de user33
+user33
+2 h
+eu quero
+Foto do perfil de user41
+user41
+2 h
+eu quero
+Foto do perfil de user46
+user46
+2 h
+eu quero
+Foto do perfil de user39
+user39
+2 h
+eu quero
+Foto do perfil de user36
+user36
+2 h
+eu quero
+Foto do perfil de user9
+user9
+2 h
+eu quero
+Foto do perfil de user14
+user14
+2 h
+eu quero
+Foto do perfil de user30
+user30
+2 h
+eu quero
+Foto do perfil de user8
+user8
+2 h
+eu quero
+Foto do perfil de user10
+user10
+2 h
+eu quero
+Foto do perfil de user17
+user17
+2 h
+eu quero
+Foto do perfil de user18
+user18
+2 h
+eu quero
+Foto do perfil de user12
+user12
+2 h
+eu quero
+Foto do perfil de user22
+user22
+2 h
+eu quero
+Foto do perfil de user16
+user16
+2 h
+eu quero


### PR DESCRIPTION
## Summary
- fix test discovery by providing top-level directory to unittest
- always show Instagram raffle history section on homepage
- add example dataset for Instagram comment parser tests

## Testing
- `python tests/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68725c32299c832a80abb36b5309dfbe