### PR TITLE
Fix instagram sweepstakes bugs

### DIFF
--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -36,6 +36,9 @@ class SorteioAnimado {
         this.timeoutIds = [];
         this.ultimoVencedor = null; // Para armazenar o último item mostrado
         this.sorteioLojasComSucesso = false; // Flag para controlar reload
+        this.sorteioConcluidoComSucesso = false; // Controla reload ao fechar o modal
+        this.sorteioId = null; // Armazenado pelo template
+        this.csrfToken = ''; // Token CSRF para requisições AJAX
     }
 
     // Inicializa o sorteio de lojas
@@ -123,6 +126,9 @@ class SorteioAnimado {
                                 
                                 <!-- Coluna dos Ganhadores (Direita) -->
                                 <div class="sorteio-col-ganhadores">
+                                    <div class="ganhadores-header">
+                                        <h5>Ganhadores</h5>
+                                    </div>
                                     <div class="ganhadores-content">
                                         <ul class="list-group list-group-flush" id="listaGanhadores"></ul>
                                     </div>

--- a/app/templates/admin/instagram_participantes.html
+++ b/app/templates/admin/instagram_participantes.html
@@ -591,6 +591,7 @@
             <h5 class="mb-0">{% if sorteio.status == 'sorteado' %}Resultados do Sorteio{% else %}Ações do Sorteio{% endif %}</h5>
         </div>
         <div class="card-body text-center">
+            <div class="ganhadores-header d-none"></div>
     {% if sorteio.status != 'sorteado' %}
                 <div class="row align-items-center">
                     <div class="col-md-4">

--- a/app/utils.py
+++ b/app/utils.py
@@ -41,18 +41,21 @@ def parse_instagram_comments(text, palavra_chave='EU QUERO', tickets_maximos=30)
     
     for bloco in blocos:
         linhas = [line.strip() for line in bloco.splitlines() if line.strip()]
-        
+
         if not linhas or not linhas[0].startswith("Foto do perfil de"):
             continue
-            
+
         if len(linhas) < 2:
             continue
-            
-        # O username é extraído da primeira linha.
-        username = linhas[0].replace("Foto do perfil de ", "").strip()
-        
-        # O username se repete na segunda linha, o que confirma a estrutura do bloco.
-        if linhas[1] != username:
+
+        # O username é extraído da primeira linha de forma robusta
+        m = re.match(r"Foto do perfil de\s+(.+)", linhas[0])
+        if not m:
+            continue
+        username = m.group(1).strip()
+
+        # O username se repete na segunda linha, normalizando maiúsculas/minúsculas
+        if linhas[1].strip().lower() != username.lower():
             continue
         
         # O comentário é a primeira linha "real" após o username e a linha de tempo.


### PR DESCRIPTION
## Summary
- initialize more state variables in `SorteioAnimado`
- show winners header in the modal markup
- add placeholder `.ganhadores-header` to participants page
- improve parsing of Instagram comments

## Testing
- `pytest -q tests/test_sorteios.py::test_instagram_sorteio_layout` *(fails: command not found)*
- `pytest -q tests/test_integration.py::test_parser_com_arquivo_real` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68725c32299c832a80abb36b5309dfbe